### PR TITLE
fix: flickering darkMode between refresh.

### DIFF
--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -15,51 +15,51 @@ const Footer = () => {
 
   const toggleDarkModeClass = () => {
     const body = document.querySelector('body');
-    const bodyHasDarkClass = body.classList.contains('darkMode')
+    const bodyHasDarkClass = body.classList.contains('darkMode');
 
     // Don't toggle on component mount- in LightMode
-    if (!isDarkMode && !bodyHasDarkClass) return
+    if (!isDarkMode && !bodyHasDarkClass) return;
 
-    body.classList.toggle('darkMode')
-  }
+    body.classList.toggle('darkMode');
+  };
 
-  useEffect( () => {
-    toggleDarkModeClass()
-  }, [isDarkMode, toggleDarkModeClass])
+  useEffect(() => {
+    toggleDarkModeClass();
+  }, [isDarkMode]);
 
   return (
-    <footer className='footer'>
+    <footer className="footer">
       <img
         onClick={() => store.dispatch(setDarkMode(!isDarkMode))}
         src={isDarkMode ? darkModeIcon : lightModeIcon}
         alt="theme-icon"
-        style={{'cursor': 'pointer'}}
+        style={{ cursor: 'pointer' }}
       />
 
-      <div className='footer__source'>
-        <p className='footer__source' style={{"display":'inline-block'}}>
+      <div className="footer__source">
+        <p className="footer__source" style={{ display: 'inline-block' }}>
           Source:{' '}
           <a
-            href='https://disease.sh/docs'
-            target='_blank'
-            rel='noopener noreferrer'
+            href="https://disease.sh/docs"
+            target="_blank"
+            rel="noopener noreferrer"
           >
-          disease.sh
-        </a>
-      </p>
-        <div style={{"margin":"0 5px", "display":'inline-block'}}>-</div>
-        <p style={{"display":'inline-block'}}>
+            disease.sh
+          </a>
+        </p>
+        <div style={{ margin: '0 5px', display: 'inline-block' }}>-</div>
+        <p style={{ display: 'inline-block' }}>
           Built by{' '}
           <a
-            href='http://github.com/patrivet'
-            target='_blank'
-            rel='noopener noreferrer'
+            href="http://github.com/patrivet"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Pat Rivet
           </a>
         </p>
       </div>
-      <p className='footer__updated'>Updated: {updated}</p>
+      <p className="footer__updated">Updated: {updated}</p>
     </footer>
   );
 };


### PR DESCRIPTION
Remove `toggleDarkModeClass` function from a useEffect's dependancies - There was no need for the function to be a dependancy - `isDarkMode` is sufficient as the solo dependancy.  This superfluous function dependancy was causing the dark / light mode to toggle repeatedly as the `header` component re-renders multiple times during fetch of data (see separate issue* below).  With each re-render, the toggleDarkModeClass function was recreated -with a fresh reference, so the useEffect re-runs.  Adapting toggleDarkModeClass to use `useCallback` would seem overkill - the cleaner solution was to remove as it's not even needed as a dependancy.

*this is a separate issue - raised subsequently as:-

- https://github.com/patrivet/covid19-tracker/issues/24

Fixes:-
- https://github.com/patrivet/covid19-tracker/issues/22