### PR TITLE
hack patch fix for menu items.

### DIFF
--- a/client/src/components/ShowMenuItem/ShowMenuItem.js
+++ b/client/src/components/ShowMenuItem/ShowMenuItem.js
@@ -10,7 +10,7 @@ const continents = ["Africa","Asia", 'Europe', 'North America', 'Oceania', "Sout
 
 const ShowMenuItem = () => {
   let [menuShown, setMenuShown] = useState();
-  let displayModal, closeBtn;
+  // let displayModal, closeBtn;
   let showOptionElements = ['All countries', 'Bookmarked countries', ...continents];
   const currentDisplayOption = useSelector(store => store.displayMode);
 
@@ -25,27 +25,30 @@ const ShowMenuItem = () => {
     handleModalClose();
   };
 
-  const closeMenu = event => {
-    /* Check the click event is the close button or a display option
-       or NOT inside the display modal element. */
+  // ? Commented out whilst not working on react 18. Commented out references to fn as well.
+  // const closeMenu = event => {
+  //   /* Check the click event is the close button or a display option
+  //      or NOT inside the display modal element. */
 
-    /* Handling click other than on a display option - as longer the X or *outside* the modal -
-    close the modal. */
-    if (!displayModal.contains(event.target) || closeBtn === event.target) {
-      handleModalClose();
-    }
-  };
+  //   /* Handling click other than on a display option - as longer the X or *outside* the modal -
+  //   close the modal. */
+
+  //   if (!displayModal.contains(event.target) || closeBtn === event.target) {
+  //     handleModalClose();
+  //   }
+  // };
 
   const handleModalClose = () => {
     setMenuShown(false);
-    document.removeEventListener('click', closeMenu);
+    // document.removeEventListener('click', closeMenu);
     helpers.toggleBlurClasses();
   };
 
   useEffect(() => {
     if (menuShown) {
-      document.addEventListener('click', closeMenu);
+      // document.addEventListener('click', closeMenu);
       helpers.toggleBlurClasses();
+      // return () => document.removeEventListener('click', closeMenu);
     }
   }, [menuShown]);
 
@@ -60,14 +63,15 @@ const ShowMenuItem = () => {
         <div
           className='menu'
           /* Store a ref to the DOM element */
-          ref={element => {
-            displayModal = element;
-          }}
+          // ref={element => {
+          //   displayModal = element;
+          // }}
         >
         <button className='menu__close'
-          ref={element => {
-            closeBtn = element;
-          }}
+          // ref={element => {
+          //   closeBtn = element;
+          // }}
+          onClick={handleModalClose}
         >
           &times;
         </button>

--- a/client/src/components/Sort/Sort.js
+++ b/client/src/components/Sort/Sort.js
@@ -13,7 +13,7 @@ import * as helpers from '../../utils/helperFunctions';
 
 const Sort = () => {
   let [menuShown, setMenuShown] = useState();
-  let sortModal, closeBtn;
+  // let sortModal, closeBtn;
   let sortOptionElements = [];
   const activeSortOption = useSelector(store => store.sorting);
 
@@ -35,29 +35,30 @@ const Sort = () => {
     return activeSortOption.label === sortToSet.label && activeSortOption.direction === sortToSet.direction
   }
 
-  function closeMenu (event) {
-    /* Check the click event is the close button or a sort option
-       or NOT inside the sort modal element. */
+  // ? Commented out whilst not working on react 18. Commented out references to fn as well.
+  // function closeMenu (event) {
+  //   /* Check the click event is the close button or a sort option
+  //      or NOT inside the sort modal element. */
 
-    /* Handling click other than on a sort option - as longer the X or *outside* the modal -
-    close the modal. */
-    if (!sortModal.contains(event.target) || closeBtn === event.target) {
-      handleModalClose();
-    }
-  };
+  //   /* Handling click other than on a sort option - as longer the X or *outside* the modal -
+  //   close the modal. */
+  //   if (!sortModal.contains(event.target) || closeBtn === event.target) {
+  //     handleModalClose();
+  //   }
+  // };
 
   const handleModalClose = () => {
     setMenuShown(false);
-    document.removeEventListener('click', closeMenu);
+    // document.removeEventListener('click', closeMenu);
     helpers.toggleBlurClasses();
   };
 
   useEffect(() => {
     if (menuShown) {
-      document.addEventListener('click', closeMenu);
+      // document.addEventListener('click', closeMenu);
       helpers.toggleBlurClasses();
     }
-  }, [closeMenu, menuShown]);
+  }, [menuShown]);
 
   const getArrow = (direction, sortOption) => {
     const sortOptionCopy = {...sortOption, direction};
@@ -91,14 +92,15 @@ const Sort = () => {
         <div
           className='menu'
           /* Store a ref to the DOM element */
-          ref={element => {
-            sortModal = element;
-          }}
+          // ref={element => {
+          //   sortModal = element;
+          // }}
         >
           <button
-            ref={element => {
-              closeBtn = element;
-            }}
+            // ref={element => {
+            //   closeBtn = element;
+            // }}
+            onClick={handleModalClose}
             className='menu__close'
           >
             &times;
@@ -130,7 +132,6 @@ const Sort = () => {
             {/* THIS DOESN'T WORK SO USING FUNCTION INSTEAD OF COMPONENT <Arrow selected={true} sortOption={opt} /> */}
 
             {sortOptions.map(option => {
-              console.log("🚀 ~ file: Sort.js ~ line 133 ~ Sort ~ option", option)
               /* Mark the active sort option an 'active' class, all others add an 'inactive' class. */
               let classNames =
                 activeSortOption.label === option.label


### PR DESCRIPTION
Hack patch - comments out adding event listener to `document` and the passed function to the event listeners.

To be revisited to discover underlying cause of why the menu item modal fails  to show since upgrade to v18.2.0 of react.